### PR TITLE
👷‍♂️ Delete Solidity linguist git attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-*.sol linguist-language=Solidity
 .gas-snapshot linguist-language=Julia


### PR DESCRIPTION
## Description

It is no longer necessary to specify `linguist-language=Solidity` in `.gitattributes` for GitHub to show syntax highlighting for Solidity code.
