### PR TITLE
replace RETURNDATASIZE with PUSH0 for CREATE3 proxy

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,7 @@
 solc = "0.8.15"
 bytecode_hash = "none"
 optimizer_runs = 1000000
+evm_version = "shanghai"
 
 [profile.intense.fuzz]
 runs = 10000

--- a/src/utils/CREATE3.sol
+++ b/src/utils/CREATE3.sol
@@ -13,24 +13,24 @@ library CREATE3 {
     // Opcode     | Opcode + Arguments    | Description      | Stack View             //
     //--------------------------------------------------------------------------------//
     // 0x36       |  0x36                 | CALLDATASIZE     | size                   //
-    // 0x3d       |  0x3d                 | RETURNDATASIZE   | 0 size                 //
-    // 0x3d       |  0x3d                 | RETURNDATASIZE   | 0 0 size               //
+    // 0x5f       |  0x5f                 | PUSH0            | 0 size                 //
+    // 0x5f       |  0x5f                 | PUSH0            | 0 0 size               //
     // 0x37       |  0x37                 | CALLDATACOPY     |                        //
     // 0x36       |  0x36                 | CALLDATASIZE     | size                   //
-    // 0x3d       |  0x3d                 | RETURNDATASIZE   | 0 size                 //
+    // 0x5f       |  0x5f                 | PUSH0            | 0 size                 //
     // 0x34       |  0x34                 | CALLVALUE        | value 0 size           //
     // 0xf0       |  0xf0                 | CREATE           | newContract            //
     //--------------------------------------------------------------------------------//
     // Opcode     | Opcode + Arguments    | Description      | Stack View             //
     //--------------------------------------------------------------------------------//
     // 0x67       |  0x67XXXXXXXXXXXXXXXX | PUSH8 bytecode   | bytecode               //
-    // 0x3d       |  0x3d                 | RETURNDATASIZE   | 0 bytecode             //
+    // 0x5f       |  0x5f                 | PUSH0            | 0 bytecode             //
     // 0x52       |  0x52                 | MSTORE           |                        //
     // 0x60       |  0x6008               | PUSH1 08         | 8                      //
     // 0x60       |  0x6018               | PUSH1 18         | 24 8                   //
     // 0xf3       |  0xf3                 | RETURN           |                        //
     //--------------------------------------------------------------------------------//
-    bytes internal constant PROXY_BYTECODE = hex"67_36_3d_3d_37_36_3d_34_f0_3d_52_60_08_60_18_f3";
+    bytes internal constant PROXY_BYTECODE = hex"67_36_5f_5f_37_36_5f_34_f0_5f_52_60_08_60_18_f3";
 
     bytes32 internal constant PROXY_BYTECODE_HASH = keccak256(PROXY_BYTECODE);
 


### PR DESCRIPTION
## Description

1. Replace RETURNDATASIZE opcode with PUSH0 opcode in the CREATE3 minimum proxy
2. Update EVM version in `foundry.toml` to support Shanghai (is not yet the default version) 

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [X] Ran `forge snapshot`?
- [X] Ran `npm run lint`?
- [X] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._
