### PR TITLE
ci(forge): fix failing workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,10 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 
@@ -20,7 +20,7 @@ jobs:
         run: forge build --sizes
 
       - name: Check gas snapshots
-        run: forge snapshot --check
+        run: forge snapshot --check --tolerance 3
 
       - name: Run tests
         run: forge test


### PR DESCRIPTION
The previous commit saw a CI failure due to not having `--tolerance` specified. I took the difference and rounded up (~2.64% difference in gas snapshot to the value of 3). 

Also updated the foundry tool chain to the appropriate repo, and updated checkout to use v3.

## Description

Describe the changes made in your pull request here.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Ran `forge snapshot`?
- [ ] Ran `npm run lint`?
- [ ] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._
