### PR TITLE
added beforeDeposit and afterWithdrawal hooks to ERC4626

### DIFF
--- a/src/test/CREATE3.t.sol
+++ b/src/test/CREATE3.t.sol
@@ -40,10 +40,8 @@ contract CREATE3Test is DSTestPlus {
         bytes32 salt = keccak256(bytes("A salt!"));
         Factory factory = new Factory();
 
-        MockERC20 deployed = MockERC20(
-            factory.deploy(salt)
-        );
-    
+        MockERC20 deployed = MockERC20(factory.deploy(salt));
+
         assertEq(address(deployed), CREATE3.getDeployed(salt, address(factory)));
         assertTrue(address(deployed) != CREATE3.getDeployed(salt));
 

--- a/src/tokens/ERC4626.sol
+++ b/src/tokens/ERC4626.sol
@@ -192,5 +192,4 @@ abstract contract ERC4626 is ERC20 {
     function afterDeposit(uint256 assets, uint256 shares) internal virtual {}
 
     function afterWithdraw(uint256 assets, uint256 shares) internal virtual {}
-
 }

--- a/src/tokens/ERC4626.sol
+++ b/src/tokens/ERC4626.sol
@@ -47,6 +47,8 @@ abstract contract ERC4626 is ERC20 {
         // Check for rounding error since we round down in previewDeposit.
         require((shares = previewDeposit(assets)) != 0, "ZERO_SHARES");
 
+        beforeDeposit(assets, shares);
+
         // Need to transfer before minting or ERC777s could reenter.
         asset.safeTransferFrom(msg.sender, address(this), assets);
 
@@ -59,6 +61,8 @@ abstract contract ERC4626 is ERC20 {
 
     function mint(uint256 shares, address receiver) public virtual returns (uint256 assets) {
         assets = previewMint(shares); // No need to check for rounding error, previewMint rounds up.
+
+        beforeDeposit(assets, shares);
 
         // Need to transfer before minting or ERC777s could reenter.
         asset.safeTransferFrom(msg.sender, address(this), assets);
@@ -90,6 +94,8 @@ abstract contract ERC4626 is ERC20 {
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
 
         asset.safeTransfer(receiver, assets);
+
+        afterWithdraw(assets, shares);
     }
 
     function redeem(
@@ -113,6 +119,8 @@ abstract contract ERC4626 is ERC20 {
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
 
         asset.safeTransfer(receiver, assets);
+
+        afterWithdraw(assets, shares);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -177,7 +185,12 @@ abstract contract ERC4626 is ERC20 {
                           INTERNAL HOOKS LOGIC
     //////////////////////////////////////////////////////////////*/
 
+    function beforeDeposit(uint256 assets, uint256 shares) internal virtual {}
+
     function beforeWithdraw(uint256 assets, uint256 shares) internal virtual {}
 
     function afterDeposit(uint256 assets, uint256 shares) internal virtual {}
+
+    function afterWithdraw(uint256 assets, uint256 shares) internal virtual {}
+
 }

--- a/src/utils/SafeTransferLib.sol
+++ b/src/utils/SafeTransferLib.sol
@@ -53,7 +53,7 @@ library SafeTransferLib {
             // Set success to whether the call reverted, if not we check it either
             // returned exactly 1 (can't just be non-zero data), or had no return data and token has code.
             if and(iszero(and(eq(mload(0), 1), gt(returndatasize(), 31))), success) {
-                success := iszero(or(iszero(extcodesize(token)), returndatasize())) 
+                success := iszero(or(iszero(extcodesize(token)), returndatasize()))
             }
         }
 
@@ -84,7 +84,7 @@ library SafeTransferLib {
             // Set success to whether the call reverted, if not we check it either
             // returned exactly 1 (can't just be non-zero data), or had no return data and token has code.
             if and(iszero(and(eq(mload(0), 1), gt(returndatasize(), 31))), success) {
-                success := iszero(or(iszero(extcodesize(token)), returndatasize())) 
+                success := iszero(or(iszero(extcodesize(token)), returndatasize()))
             }
         }
 
@@ -115,7 +115,7 @@ library SafeTransferLib {
             // Set success to whether the call reverted, if not we check it either
             // returned exactly 1 (can't just be non-zero data), or had no return data and token has code.
             if and(iszero(and(eq(mload(0), 1), gt(returndatasize(), 31))), success) {
-                success := iszero(or(iszero(extcodesize(token)), returndatasize())) 
+                success := iszero(or(iszero(extcodesize(token)), returndatasize()))
             }
         }
 


### PR DESCRIPTION
## Description

Some implementations of 4626 require actions before a deposit. There is no `beforeDeposit()` hook, so I took the liberty of adding it. Likewise, there is no `afterWithdrawal()` hook, which may be similarly useful at times. I added that as well. 

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?

I ran forge test, but my new version of foundry is complaining that testFail does not exist any more. Simply adding virtual hook functions shouldn't fail any tests that came before, and I don't want to modify the whole test suite, I'm not sure what is going on with that. 
